### PR TITLE
Restrict resources for users

### DIFF
--- a/data/seed.json
+++ b/data/seed.json
@@ -1,65 +1,47 @@
 {
   "store": {
-    "currencies": [
-      "eur",
-      "usd"
-    ]
+    "currencies": ["eur", "usd"]
   },
   "users": [
-		{
-			"email": "abdul@bikeexchange.de",
-			"password": "test@123"
-		},
-		{
-			"email": "ayoub@bikeexchange.de",
-			"password": "test@123"
-		},
-		{
-			"email": "markus@bikeexchange.de",
-			"password": "test@123"
-		},
-		{
-			"email": "henning@bikeexchange.de",
-			"password": "test@123"
-		}
-	],
+    {
+      "email": "abdul@bikeexchange.de",
+      "password": "test@123",
+      "role": "admin"
+    },
+    {
+      "email": "ayoub@bikeexchange.de",
+      "password": "test@123",
+      "role": "admin"
+    },
+    {
+      "email": "markus@bikeexchange.de",
+      "password": "test@123",
+      "role": "admin"
+    },
+    {
+      "email": "henning@bikeexchange.de",
+      "password": "test@123",
+      "role": "admin"
+    }
+  ],
   "regions": [
     {
       "id": "test-region-eu",
       "name": "EU",
       "currency_code": "eur",
       "tax_rate": 0,
-      "payment_providers": [
-        "manual"
-      ],
-      "fulfillment_providers": [
-        "manual"
-      ],
-      "countries": [
-        "gb",
-        "de",
-        "dk",
-        "se",
-        "fr",
-        "es",
-        "it"
-      ]
+      "payment_providers": ["manual"],
+      "fulfillment_providers": ["manual"],
+      "countries": ["gb", "de", "dk", "se", "fr", "es", "it"]
     },
     {
       "id": "test-region-na",
       "name": "NA",
       "currency_code": "usd",
       "tax_rate": 0,
-      "payment_providers": [
-        "manual"
-      ],
-      "fulfillment_providers": [
-        "manual"
-      ],
-      "countries": [
-        "us",
-        "ca"
-      ]
+      "payment_providers": ["manual"],
+      "fulfillment_providers": ["manual"],
+      "countries": ["us", "ca"]
     }
   ],
   "shipping_options": [

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@medusajs/medusa": "^1.20.6",
     "@tanstack/react-query": "4.22.0",
     "body-parser": "^1.19.0",
+    "class-validator": "^0.14.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.17.2",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,11 @@
+import { registerOverriddenValidators } from "@medusajs/medusa";
+import { AdminCreateUserRequest as MedusaAdminCreateUserRequest } from "@medusajs/medusa/dist/api/routes/admin/users/create-user";
+import { IsOptional, IsString } from "class-validator";
+
+class AdminCreateUserRequest extends MedusaAdminCreateUserRequest {
+  @IsString()
+  @IsOptional()
+  store_id?: string;
+}
+
+registerOverriddenValidators(AdminCreateUserRequest);

--- a/src/utils/checkIsAdminUser.ts
+++ b/src/utils/checkIsAdminUser.ts
@@ -1,0 +1,6 @@
+import { UserRoles } from "@medusajs/medusa";
+import { User } from "../models/user";
+
+export const checkIsAdminUser = (user: User | null): boolean => {
+  return user?.role === UserRoles.ADMIN;
+};


### PR DESCRIPTION
PR to restrict resources access for users.
with this PR, we have the following changes:

- admin users can see all users (even one who do not belong to the same user's store)
- admin can see/manage all products
- non admin users can see only users of the same store
- non admin users can only see products of their store